### PR TITLE
add reminder about unused subscription

### DIFF
--- a/elk/settings.py
+++ b/elk/settings.py
@@ -321,6 +321,10 @@ CELERYBEAT_SCHEDULE = {
         'task': 'accounting.tasks.bill_timeline_entries',
         'schedule': timedelta(minutes=1),
     },
+    'check_students_wasting_subscription': {
+        'task': 'timeline.tasks.remind_student_of_subscription',
+        'schedule': timedelta(days=1),
+    },
 }
 
 

--- a/timeline/signals.py
+++ b/timeline/signals.py
@@ -5,6 +5,7 @@ from mailer.owl import Owl
 
 class_starting_teacher = Signal(providing_args=['instance'])  # class is about to start (for teachers)
 class_starting_student = Signal(providing_args=['instance'])  # class is about to start (for students)
+subscription_reminder_student = Signal(providing_args=['instance'])  # student hasn't been to class in over a week
 #
 # i have made two different signals, because they obviously will require different
 # options, like time, left to the lesson
@@ -34,5 +35,19 @@ def notify_class_starting_teacher(sender, **kwargs):
         },
         to=[c.timeline.teacher.user.email],
         timezone=c.timeline.teacher.user.crm.timezone,
+    )
+    owl.send()
+
+
+@receiver(subscription_reminder_student, dispatch_uid='notify_subscription_reminder_student')
+def notify_subscription_reminder_student(sender, **kwargs):
+    c = kwargs['instance']
+    owl = Owl(
+        template='mail/class/student/subscription_reminder.html',
+        ctx={
+            'c': c,
+        },
+        to=[c.customer.user.email],
+        timezone=c.customer.timezone,
     )
     owl.send()

--- a/timeline/tasks.py
+++ b/timeline/tasks.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 from elk.celery import app as celery
 from market.models import Class
-from timeline.signals import class_starting_student, class_starting_teacher
+from timeline.signals import class_starting_student, class_starting_teacher, subscription_reminder_student
 
 
 @celery.task
@@ -20,3 +20,10 @@ def notify_15min_to_class():
         i.pre_start_notifications_sent_to_student = True
         i.save()
         class_starting_student.send(sender=notify_15min_to_class, instance=i)
+
+
+@celery.task
+def remind_student_of_subscription():
+    for i in Class.objects.classes_more_than_1_week_ago():
+        subscription_reminder_student.send(sender=remind_student_of_subscription, instance=i)
+

--- a/timeline/templates/mail/class/student/subscription_reminder.html
+++ b/timeline/templates/mail/class/student/subscription_reminder.html
@@ -1,0 +1,14 @@
+{% extends "mail_templated/base.tpl" %}
+{% load humanize %}
+
+{% block subject %}
+{{ c.customer.first_name | capfirst }}, your {{ c.timeline.lesson.type_verbose_name }} is about to start!
+{% endblock %}
+
+{% block body %}
+Dear {{ c.customer.first_name | capfirst }},
+
+You have an active subscription, and haven't taken a class in over a week.
+
+{% include 'mailer/_signature.html' %}
+{% endblock %}


### PR DESCRIPTION
Added ClassesManager method `classes_more_than_1_week_ago`, a Signal `subscription_reminder_student`, a celery task `remind_student_of_subscription` and a `CELERYBEAT_SCHEDULE` `check_students_wasting_subscription`. 

The frequency with which emails should be sent was not specified, I've chosen 1 day. Every day the task will check, which students with active subscriptions haven't had a class in over a week, and send a reminder email to them. 

Testing will require more time, let me know if tests are needed. 